### PR TITLE
Refactor UI pages to MudBlazor components

### DIFF
--- a/HotelMePWA/Pages/AdminChatLogPage.razor
+++ b/HotelMePWA/Pages/AdminChatLogPage.razor
@@ -3,65 +3,58 @@
 @inject ChatService ChatService
 @inject AuthService AuthService
 
-<h3>💬 All Chat Messages</h3>
+<MudText Typo="Typo.h5" Class="mb-2">💬 All Chat Messages</MudText>
 
 @if (!isReady)
 {
-    <p>⏳ Loading…</p>
+    <MudProgressCircular Indeterminate="true" Class="my-4" />
 }
 else if (!isAdmin)
 {
-    <p class="text-danger">⛔ Достъп само за администратори.</p>
+    <MudText Color="Color.Error">⛔ Достъп само за администратори.</MudText>
 }
 else if (messages.Count == 0)
 {
-    <p class="text-muted">Няма изпратени съобщения.</p>
+    <MudText Color="Color.Secondary">Няма изпратени съобщения.</MudText>
 }
 else
 {
-    <table class="table table-striped">
-        <thead>
-            <tr>
-                <th>#</th>
-                <th>User ID</th>
-                <th>Message</th>
-                <th>Sent At</th>
-                <th>Checked-In?</th>
-                <th>Room</th>           <!-- NEW column -->
-            </tr>
-        </thead>
-        <tbody>
-            @foreach (var m in messages)
-            {
-                <tr>
-                    <td>@m.Id</td>
-                    <td>@m.UserId</td>
-                    <td>@m.Message</td>
-                    <td>@m.SentAt.ToLocalTime().ToString("g")</td>
-                    <td>
-                        @if (m.HasActiveBooking)
-                        {
-                            <span class="text-success">Yes</span>
-                        }
-                        else
-                        {
-                            <span class="text-secondary">No</span>
-                        }
-                    </td>
-                    <td>
-                        @if (m.HasActiveBooking && m.RoomNumber != null)
-                        {
-                            @m.RoomNumber
-                        }
-                        else
-                        {
-                            <span class="text-muted">—</span>
-                        }
-                    </td>
-                </tr>
-            }
-        </tbody>
-    </table>
+    <MudTable Items="messages" Elevation="1" Dense="true">
+        <HeaderContent>
+            <MudTh>#</MudTh>
+            <MudTh>User ID</MudTh>
+            <MudTh>Message</MudTh>
+            <MudTh>Sent At</MudTh>
+            <MudTh>Checked-In?</MudTh>
+            <MudTh>Room</MudTh>
+        </HeaderContent>
+        <RowTemplate>
+            <MudTd DataLabel="#">@context.Id</MudTd>
+            <MudTd DataLabel="User ID">@context.UserId</MudTd>
+            <MudTd DataLabel="Message">@context.Message</MudTd>
+            <MudTd DataLabel="Sent At">@context.SentAt.ToLocalTime().ToString("g")</MudTd>
+            <MudTd DataLabel="Checked-In?">
+                @if (context.HasActiveBooking)
+                {
+                    <MudText Color="Color.Success">Yes</MudText>
+                }
+                else
+                {
+                    <MudText Color="Color.Secondary">No</MudText>
+                }
+            </MudTd>
+            <MudTd DataLabel="Room">
+                @if (context.HasActiveBooking && context.RoomNumber != null)
+                {
+                    @context.RoomNumber
+                }
+                else
+                {
+                    <MudText Color="Color.Secondary">—</MudText>
+                }
+            </MudTd>
+        </RowTemplate>
+    </MudTable>
 }
 
 @code {

--- a/HotelMePWA/Pages/AdminOrders.razor
+++ b/HotelMePWA/Pages/AdminOrders.razor
@@ -3,55 +3,45 @@
 @inject OrderService OrderService
 @inject AuthService AuthService
 
-<h3>📦 All Orders (Admin)</h3>
+<MudText Typo="Typo.h5" Class="mb-2">📦 All Orders (Admin)</MudText>
 
 @if (!isReady)
 {
-    <p>⏳ Loading…</p>
+    <MudProgressCircular Indeterminate="true" Class="my-4" />
 }
 else if (!isAdmin)
 {
-    <p class="text-danger">⛔ Only admins can view this.</p>
+    <MudText Color="Color.Error">⛔ Only admins can view this.</MudText>
 }
 else if (orders.Count == 0)
 {
-    <p class="text-muted">No orders yet.</p>
+    <MudText Color="Color.Secondary">No orders yet.</MudText>
 }
 else
 {
-    <table class="table table-striped">
-        <thead>
-            <tr>
-                <th>#</th>
-                <th>Room</th>
-                <th>Items</th>
-                <th>Created</th>
-                <th>Status</th>
-                <th></th>
-            </tr>
-        </thead>
-        <tbody>
-            @foreach (var o in orders)
-            {
-                <tr>
-                    <td>@o.Id</td>
-                    <td>@(o.RoomNumber ?? "—")</td>
-                    <td>@o.ItemsSummary</td>
-                    <td>@o.CreatedAt.ToLocalTime().ToString("g")</td>
-                    <td>@o.Status</td>
-                    <td>
-                        @if (o.Status == "Pending")
-                        {
-                            <button class="btn btn-sm btn-success"
-                                    @onclick="() => Complete(o.Id)">
-                                Complete
-                            </button>
-                        }
-                    </td>
-                </tr>
-            }
-        </tbody>
-    </table>
+    <MudTable Items="orders" Elevation="1" Dense="true">
+        <HeaderContent>
+            <MudTh>#</MudTh>
+            <MudTh>Room</MudTh>
+            <MudTh>Items</MudTh>
+            <MudTh>Created</MudTh>
+            <MudTh>Status</MudTh>
+            <MudTh></MudTh>
+        </HeaderContent>
+        <RowTemplate>
+            <MudTd DataLabel="#">@context.Id</MudTd>
+            <MudTd DataLabel="Room">@(context.RoomNumber ?? "—")</MudTd>
+            <MudTd DataLabel="Items">@context.ItemsSummary</MudTd>
+            <MudTd DataLabel="Created">@context.CreatedAt.ToLocalTime().ToString("g")</MudTd>
+            <MudTd DataLabel="Status">@context.Status</MudTd>
+            <MudTd DataLabel="">
+                @if (context.Status == "Pending")
+                {
+                    <MudButton Color="Color.Success" Variant="Variant.Filled" Size="Size.Small" OnClick="() => Complete(context.Id)">Complete</MudButton>
+                }
+            </MudTd>
+        </RowTemplate>
+    </MudTable>
 }
 
 @code {

--- a/HotelMePWA/Pages/AdminPanel.razor
+++ b/HotelMePWA/Pages/AdminPanel.razor
@@ -4,44 +4,37 @@
 
 @if (!isAuthenticated || userRole != "Admin")
 {
-    <p class="text-danger">⛔ Трябва да сте влезли като администратор!</p>
+    <MudText Color="Color.Error">⛔ Трябва да сте влезли като администратор!</MudText>
 }
 else if (isLoading)
 {
-    <p>⏳ Зареждане...</p>
+    <MudProgressCircular Indeterminate="true" Class="my-4" />
 }
 else
 {
-    <h3>👑 Администраторски панел</h3>
+    <MudText Typo="Typo.h5" Class="mb-2">👑 Администраторски панел</MudText>
 
     @if (users != null && users.Count > 0)
     {
-        <table class="table mt-3">
-            <thead>
-                <tr>
-                    <th>#</th>
-                    <th>Потребителско име</th>
-                    <th>Email</th>
-                </tr>
-            </thead>
-            <tbody>
-                @foreach (var user in users)
-                {
-                    <tr>
-                        <td>@user.Id</td>
-                        <td>@user.UserName</td> <!-- ApplicationUser uses UserName instead of Name -->
-                        <td>@user.Email</td>
-                    </tr>
-                }
-            </tbody>
-        </table>
+        <MudTable Items="users" Dense="true" Class="mt-3">
+            <HeaderContent>
+                <MudTh>#</MudTh>
+                <MudTh>Потребителско име</MudTh>
+                <MudTh>Email</MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd DataLabel="#">@context.Id</MudTd>
+                <MudTd DataLabel="Потребителско име">@context.UserName</MudTd>
+                <MudTd DataLabel="Email">@context.Email</MudTd>
+            </RowTemplate>
+        </MudTable>
     }
     else
     {
-        <p class="text-muted">Няма налични потребители.</p>
+        <MudText Color="Color.Secondary">Няма налични потребители.</MudText>
     }
 
-    <button class="btn btn-primary" @onclick="LoadUsers">🔄 Презареди потребители</button>
+    <MudButton Color="Color.Primary" OnClick="LoadUsers" Class="mt-2">🔄 Презареди потребители</MudButton>
 }
 
 @code {

--- a/HotelMePWA/Pages/BookRoomPage.razor
+++ b/HotelMePWA/Pages/BookRoomPage.razor
@@ -3,64 +3,43 @@
 @inject AuthService AuthService
 @inject NavigationManager Nav
 
-<h3>📅 Make a Booking</h3>
+<MudText Typo="Typo.h5" Class="mb-2">📅 Make a Booking</MudText>
 
 @if (!isReady)
 {
-    <p>⏳ Checking authentication…</p>
+    <MudProgressCircular Indeterminate="true" Class="my-4" />
 }
 else if (!isAuthenticated)
 {
-    <p class="text-danger">
-        ⛔ You must <a @onclick="GoLogin">log in</a> first.
-    </p>
+    <MudText Color="Color.Error">
+        ⛔ You must <MudLink Href="/login">log in</MudLink> first.
+    </MudText>
 }
 else if (existingBooking != null)
 {
-    <p class="text-success">
+    <MudAlert Severity="Severity.Success" Variant="Variant.Filled">
         ✅ You already have a booking for room <strong>@existingBooking.RoomNumber</strong>
         from <strong>@existingBooking.CheckInDate.ToShortDateString()</strong>
         to <strong>@existingBooking.CheckOutDate.ToShortDateString()</strong>.
-    </p>
-    <p>
-        <a class="btn btn-secondary" href="/checkin">Go to Check-in Page</a>
-    </p>
+    </MudAlert>
+    <MudButton Variant="Variant.Filled" Color="Color.Secondary" Class="mt-2" Href="/checkin">Go to Check-in Page</MudButton>
 }
 else
 {
-    <EditForm Model="request" OnValidSubmit="SubmitBooking">
-        <DataAnnotationsValidator />
-        <ValidationSummary />
+    <MudForm Model="request" @ref="form" OnValidSubmit="SubmitBooking">
+        <MudTextField @bind-Value="request.RoomNumber" Label="Room Number" Class="mb-3" />
+        <MudDatePicker @bind-Date="request.CheckInDate" Label="Check‑in Date" Class="mb-3" />
+        <MudDatePicker @bind-Date="request.CheckOutDate" Label="Check‑out Date" Class="mb-3" />
 
-        <div class="mb-3">
-            <label>Room Number</label>
-            <InputText class="form-control" @bind-Value="request.RoomNumber" />
-        </div>
-        <div class="mb-3">
-            <label>Check‑in Date</label>
-            <InputDate @bind-Value="request.CheckInDate" class="form-control" />
-        </div>
-        <div class="mb-3">
-            <label>Check‑out Date</label>
-            <InputDate @bind-Value="request.CheckOutDate" class="form-control" />
-        </div>
-
-        <button class="btn btn-primary" disabled="@isSubmitting">
-            @if (isSubmitting)
-            {
-                <span>⏳ Booking…</span>
-            }
-            else
-            {
-                <span>✅ Book Now</span>
-            }
-        </button>
+        <MudButton Color="Color.Primary" Disabled="@isSubmitting" Type="Submit">
+            @(isSubmitting ? (MarkupString)"⏳ Booking…" : (MarkupString)"✅ Book Now")
+        </MudButton>
 
         @if (!string.IsNullOrEmpty(feedback))
         {
-            <p class="mt-2">@feedback</p>
+            <MudText Class="mt-2">@feedback</MudText>
         }
-    </EditForm>
+    </MudForm>
 }
 
 @code {
@@ -72,6 +51,7 @@ else
     private bool isAuthenticated;
     private bool isReady;
     private bool isSubmitting;
+    private MudForm? form;
     private string? feedback;
     private Booking? existingBooking;
 

--- a/HotelMePWA/Pages/ChatPage.razor
+++ b/HotelMePWA/Pages/ChatPage.razor
@@ -1,19 +1,19 @@
 ﻿@page "/chat"
 @inject ChatService ChatService
 
-<h3>💬 Live Chat with Reception</h3>
+<MudText Typo="Typo.h5" Class="mb-2">💬 Live Chat with Reception</MudText>
 
 @if (isSending)
 {
-    <p>⏳ Sending message...</p>
+    <MudProgressCircular Indeterminate="true" Class="my-2" />
 }
 
-<input type="text" class="form-control" @bind="messageText" placeholder="Type your message..." />
-<button class="btn btn-primary mt-2" @onclick="SendMessage">📩 Send</button>
+<MudTextField @bind-Value="messageText" Placeholder="Type your message..." Class="mb-2" Immediate="true" />
+<MudButton Color="Color.Primary" OnClick="SendMessage" Disabled="@string.IsNullOrWhiteSpace(messageText)">📩 Send</MudButton>
 
 @if (!string.IsNullOrEmpty(feedbackMessage))
 {
-    <p class="text-success">@feedbackMessage</p>
+    <MudText Color="Color.Success" Class="mt-2">@feedbackMessage</MudText>
 }
 
 @code {

--- a/HotelMePWA/Pages/CheckInPage.razor
+++ b/HotelMePWA/Pages/CheckInPage.razor
@@ -3,34 +3,34 @@
 @inject AuthService AuthService
 @inject NavigationManager Nav
 
-<h3>🏨 Digital Check‑in</h3>
+<MudText Typo="Typo.h5" Class="mb-2">🏨 Digital Check‑in</MudText>
 
 @if (!isInitialized)
 {
-    <p>⏳ Loading…</p>
+    <MudProgressCircular Indeterminate="true" Class="my-4" />
 }
 else if (!isAuthenticated)
 {
-    <p class="text-danger">⛔ You need to <a @onclick="GoLogin">log in</a> as a guest first.</p>
+    <MudText Color="Color.Error">⛔ You need to <MudLink Href="/login">log in</MudLink> as a guest first.</MudText>
 }
 else if (booking == null)
 {
-    <p class="text-muted">No active booking found.</p>
+    <MudText Color="Color.Secondary">No active booking found.</MudText>
 }
 else
 {
-    <p><strong>Room:</strong> @booking.RoomNumber</p>
-    <p><strong>Check‑in Date:</strong> @booking.CheckInDate</p>
-    <p><strong>Check‑out Date:</strong> @booking.CheckOutDate</p>
-    <p><strong>Status:</strong> @booking.Status</p>
+    <MudText><b>Room:</b> @booking.RoomNumber</MudText>
+    <MudText><b>Check‑in Date:</b> @booking.CheckInDate</MudText>
+    <MudText><b>Check‑out Date:</b> @booking.CheckOutDate</MudText>
+    <MudText><b>Status:</b> @booking.Status</MudText>
 
     @if (booking.Status == "Pending")
     {
-        <button class="btn btn-success" @onclick="PerformCheckIn">✅ Check‑in</button>
+        <MudButton Color="Color.Success" OnClick="PerformCheckIn">✅ Check‑in</MudButton>
     }
     else if (booking.Status == "CheckedIn")
     {
-        <button class="btn btn-danger" @onclick="PerformCheckOut">🚪 Check‑out</button>
+        <MudButton Color="Color.Error" OnClick="PerformCheckOut">🚪 Check‑out</MudButton>
     }
 }
 

--- a/HotelMePWA/Pages/Home.razor
+++ b/HotelMePWA/Pages/Home.razor
@@ -2,6 +2,6 @@
 
 <PageTitle>Home</PageTitle>
 
-<h1>Hello, world!</h1>
+<MudText Typo="Typo.h4">Hello, world!</MudText>
 
-Welcome to your new app.
+<MudText>Welcome to your new app.</MudText>

--- a/HotelMePWA/Pages/LoginPage.razor
+++ b/HotelMePWA/Pages/LoginPage.razor
@@ -2,10 +2,10 @@
 @inject AuthService AuthService
 @inject NavigationManager Navigation
 
-<h3>Вход</h3>
-<input @bind="email" placeholder="Email" />
-<input @bind="password" type="password" placeholder="Парола" />
-<button @onclick="Login">Вход</button>
+<MudText Typo="Typo.h5" Class="mb-2">Вход</MudText>
+<MudTextField @bind-Value="email" Label="Email" Class="mb-2" />
+<MudTextField @bind-Value="password" Label="Парола" InputType="InputType.Password" Class="mb-2" />
+<MudButton Color="Color.Primary" OnClick="Login">Вход</MudButton>
 
 @code {
     private string email;

--- a/HotelMePWA/Pages/LogoutPage.razor
+++ b/HotelMePWA/Pages/LogoutPage.razor
@@ -2,7 +2,7 @@
 @inject AuthService AuthService
 @inject NavigationManager Navigation
 
-<h3>Излизане...</h3>
+<MudText Typo="Typo.h6">Излизане...</MudText>
 
 @code {
     protected override async Task OnInitializedAsync()

--- a/HotelMePWA/Pages/OrdersPage.razor
+++ b/HotelMePWA/Pages/OrdersPage.razor
@@ -2,37 +2,35 @@
 @inject OrderService OrderService
 @inject AuthService AuthService
 
-<h3>📦 My Orders</h3>
+<MudText Typo="Typo.h5" Class="mb-2">📦 My Orders</MudText>
 
 @if (!isReady)
 {
-    <p>⏳ Loading…</p>
+    <MudProgressCircular Indeterminate="true" Class="my-4" />
 }
 else if (!isAuth)
 {
-    <p class="text-danger">⛔ Please <a href="/login">log in</a>.</p>
+    <MudText Color="Color.Error">⛔ Please <MudLink Href="/login">log in</MudLink>.</MudText>
 }
 else if (orders.Count == 0)
 {
-    <p class="text-muted">You have no orders yet.</p>
+    <MudText Color="Color.Secondary">You have no orders yet.</MudText>
 }
 else
 {
     @foreach (var o in orders)
     {
-        <div class="card mb-3">
-            <div class="card-header">
-                Order #@o.Id — @o.CreatedAt.ToLocalTime().ToString("g") — <em>@o.Status</em>
-            </div>
-            <ul class="list-group list-group-flush">
-                @foreach (var i in o.Items)
-                {
-                    <li class="list-group-item">
-                        @i.MenuItemName × @i.Quantity — $@i.Price
-                    </li>
-                }
-            </ul>
-        </div>
+        <MudPaper Class="mb-3" Elevation="1">
+            <MudStack Spacing="1" Class="p-2">
+                <MudText Typo="Typo.subtitle1">Order #@o.Id — @o.CreatedAt.ToLocalTime().ToString("g") — <em>@o.Status</em></MudText>
+                <MudList Dense="true">
+                    @foreach (var i in o.Items)
+                    {
+                        <MudListItem>@i.MenuItemName × @i.Quantity — $@i.Price</MudListItem>
+                    }
+                </MudList>
+            </MudStack>
+        </MudPaper>
     }
 }
 

--- a/HotelMePWA/Pages/RegisterPage.razor
+++ b/HotelMePWA/Pages/RegisterPage.razor
@@ -2,15 +2,15 @@
 @inject AuthService AuthService
 @inject NavigationManager Navigation
 
-<h3>Регистрация</h3>
+<MudText Typo="Typo.h5" Class="mb-2">Регистрация</MudText>
 
-<input @bind="email" placeholder="Email" />
-<input @bind="password" type="password" placeholder="Парола" />
-<input @bind="confirmPassword" type="password" placeholder="Повтори паролата" />
+<MudTextField @bind-Value="email" Label="Email" Class="mb-2" />
+<MudTextField @bind-Value="password" Label="Парола" InputType="InputType.Password" Class="mb-2" />
+<MudTextField @bind-Value="confirmPassword" Label="Повтори паролата" InputType="InputType.Password" Class="mb-2" />
 
-<button @onclick="Register">Регистрация</button>
+<MudButton Color="Color.Primary" OnClick="Register">Регистрация</MudButton>
 
-<p class="text-danger">@errorMessage</p>
+<MudText Color="Color.Error">@errorMessage</MudText>
 
 @code {
     private string email;

--- a/HotelMePWA/Pages/RoomServicePage.razor
+++ b/HotelMePWA/Pages/RoomServicePage.razor
@@ -4,58 +4,59 @@
 @inject BookingService BookingService
 @inject NavigationManager Nav
 
-<h3>🍽️ Room Service Menu</h3>
+<MudText Typo="Typo.h5" Class="mb-2">🍽️ Room Service Menu</MudText>
 
 @if (!isInit)
 {
-    <p>⏳ Loading…</p>
+    <MudProgressCircular Indeterminate="true" Class="my-4" />
 }
 else if (booking == null || booking.Status != "CheckedIn")
 {
-    <p class="text-danger">
-        ⛔ You must have an active room (Checked-In) to order.
-    </p>
+    <MudText Color="Color.Error">⛔ You must have an active room (Checked-In) to order.</MudText>
 }
 else
 {
-    <p><em>Room: @booking.RoomNumber</em></p>
-    <div class="row">
+    <MudText Typo="Typo.subtitle2"><em>Room: @booking.RoomNumber</em></MudText>
+    <MudGrid Class="mt-2">
         @foreach (var item in menu)
         {
-            <div class="col-md-4 mb-3">
-                <div class="card p-3">
-                    <h5>@item.Name</h5>
-                    <p>@item.Description</p>
-                    <p><strong>Price:</strong> $@item.Price</p>
-                    <button class="btn btn-sm btn-primary" @onclick="() => AddToCart(item)">
-                        🛒 Add to cart
-                    </button>
-                </div>
-            </div>
+            <MudItem xs="12" md="4">
+                <MudCard Class="mb-3">
+                    <MudCardContent>
+                        <MudText Typo="Typo.h6">@item.Name</MudText>
+                        <MudText>@item.Description</MudText>
+                        <MudText><b>Price:</b> $@item.Price</MudText>
+                    </MudCardContent>
+                    <MudCardActions>
+                        <MudButton Color="Color.Primary" Size="Size.Small" OnClick="() => AddToCart(item)">🛒 Add to cart</MudButton>
+                    </MudCardActions>
+                </MudCard>
+            </MudItem>
         }
-    </div>
+    </MudGrid>
 
     @if (cart.Any())
     {
-        <hr />
-        <h5>Your Cart (@cart.Count):</h5>
-        <ul class="list-group mb-2">
+        <MudDivider Class="my-2" />
+        <MudText Typo="Typo.h6">Your Cart (@cart.Count):</MudText>
+        <MudList Dense="true" Class="mb-2">
             @foreach (var c in cart)
             {
-                <li class="list-group-item d-flex justify-content-between align-items-center">
-                    @c.Name
-                    <button class="btn btn-sm btn-danger" @onclick="() => RemoveFromCart(c)">✖</button>
-                </li>
+                <MudListItem>
+                    <MudText>@c.Name</MudText>
+                    <MudSpacer />
+                    <MudIconButton Icon="@Icons.Material.Filled.Close" Color="Color.Error" Size="Size.Small" OnClick="() => RemoveFromCart(c)" />
+                </MudListItem>
             }
-        </ul>
+        </MudList>
 
-        <button class="btn btn-success" @onclick="SubmitOrder" disabled="@isSubmitting">
+        <MudButton Color="Color.Success" Disabled="@isSubmitting" OnClick="SubmitOrder">
             @(isSubmitting ? "⏳ Submitting…" : "✅ Submit Order")
-        </button>
+        </MudButton>
 
         @if (!string.IsNullOrEmpty(feedback))
         {
-            <p class="mt-2">@feedback</p>
+            <MudText Class="mt-2">@feedback</MudText>
         }
     }
 }


### PR DESCRIPTION
## Summary
- convert admin, booking and user pages to MudBlazor components
- update chat, orders and room service pages
- cleanup bootstrap usages

## Testing
- `dotnet build HotelMePWA/HotelMePWA.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872558a618c832eaae11d596fb3220b